### PR TITLE
이게 또 CF 들어간 주소만 호출이 되나봐요

### DIFF
--- a/epg2xml/providers/wavve.py
+++ b/epg2xml/providers/wavve.py
@@ -135,8 +135,8 @@ class WAVVE(EPGProvider):
         try:
             contentid = request_data(url, params=param)["contentid"].strip()
 
-            # url2 = 'https://apis.wavve.com/cf/vod/contents/' + contentid
-            url2 = "https://apis.wavve.com/vod/contents/" + contentid  # 같은 주소지만 이게 더 안정적인듯
+            url2 = 'https://apis.wavve.com/cf/vod/contents/' + contentid # 둘 사이를 왔다갔다 하는 모양이네요 지금은 여기만 됩니다.
+            # url2 = "https://apis.wavve.com/vod/contents/" + contentid  
             ret = self.request(url2, params=param)
         except Exception:
             log.exception("Exception while requesting data for %s with %s", url2, param)


### PR DESCRIPTION
Wavve 상세정보 API 끝점의 `vod`를 `cf/vod`로 변경했습니다.

![image](https://github.com/epg2xml/epg2xml/assets/15166740/1907279b-9ab1-4073-999b-7045fbdb8e54)
![image](https://github.com/epg2xml/epg2xml/assets/15166740/2a965d8e-8537-4de0-9c9a-b71feb585238)
![image](https://github.com/epg2xml/epg2xml/assets/15166740/cbbb6801-c1fb-4ee3-b26a-8b55d83268ba)

완전히 바뀐건지 아니면 잠시 서버가 죽은건지 모르겠는데 조금 지켜보고 https://apis.wavve.com/vod/ 주소가 완전히 죽은 게 아니라 왔다갔다 하는 거면 두 엔드포인트 모두 호출하는 식으로 고쳐봐야 할 것 같아요.
그 외 json이 바뀌거나 한건 다행히 없어보여요 :D