### PR TITLE
refactor: 요청과 쓰기를 분리

### DIFF
--- a/epg2xml/__main__.py
+++ b/epg2xml/__main__.py
@@ -47,6 +47,15 @@ def main():
             for p in providers:
                 p.load_req_channels()
 
+            log.debug("Getting EPG...")
+            if conf.settings["parallel"]:
+                with ThreadPoolExecutor() as exe:
+                    for p in providers:
+                        exe.submit(p.get_programs)
+            else:
+                for p in providers:
+                    p.get_programs()
+
             log.info("Writing xmltv.dtd header...")
             print('<?xml version="1.0" encoding="UTF-8"?>')
             print('<!DOCTYPE tv SYSTEM "xmltv.dtd">\n')
@@ -56,15 +65,6 @@ def main():
             log.debug("Writing channels...")
             for p in providers:
                 p.write_channels()
-
-            log.debug("Getting EPG...")
-            if conf.settings["parallel"]:
-                with ThreadPoolExecutor() as exe:
-                    for p in providers:
-                        exe.submit(p.get_programs)
-            else:
-                for p in providers:
-                    p.get_programs()
 
             log.debug("Writing programs...")
             for p in providers:

--- a/epg2xml/providers/__init__.py
+++ b/epg2xml/providers/__init__.py
@@ -116,7 +116,7 @@ class EPGProvider:
                 chel.append(Element("icon", src=ch.icon))
             print(chel.tostring(level=1))
 
-    def get_programs(self, lazy_write: bool = False) -> None:
+    def get_programs(self) -> None:
         raise NotImplementedError("method 'get_programs' must be implemented")
 
     def write_programs(self) -> None:

--- a/epg2xml/providers/daum.py
+++ b/epg2xml/providers/daum.py
@@ -50,7 +50,7 @@ class DAUM(EPGProvider):
                 )
         return svc_channels
 
-    def get_programs(self, lazy_write: bool = False) -> None:
+    def get_programs(self) -> None:
         url = "https://search.daum.net/search?DA=B3T&w=tot&rtmaxcoll=B3T&q={}"
         for idx, _ch in enumerate(self.req_channels):
             log.info("%03d/%03d %s", idx + 1, len(self.req_channels), _ch)
@@ -64,8 +64,6 @@ class DAUM(EPGProvider):
                 log.exception("프로그램 파싱 중 예외: %s", _ch)
             else:
                 _ch.programs.extend(_epgs)
-            if not lazy_write:
-                _ch.to_xml(self.cfg, no_endtime=self.no_endtime)
 
     def __epgs_of_days(self, channelid: str, data: str) -> List[EPGProgram]:
         soup = BeautifulSoup(data)

--- a/epg2xml/providers/daum.py
+++ b/epg2xml/providers/daum.py
@@ -3,7 +3,7 @@ from datetime import datetime, timedelta
 from typing import List
 from urllib.parse import quote
 
-from epg2xml.providers import EPGProgram, EPGProvider
+from epg2xml.providers import EPGProgram, EPGProvider, no_endtime
 from epg2xml.utils import ParserBeautifulSoup as BeautifulSoup
 
 log = logging.getLogger(__name__.rsplit(".", maxsplit=1)[-1].upper())
@@ -22,7 +22,6 @@ class DAUM(EPGProvider):
     """
 
     referer = None
-    no_endtime = True
     title_regex = r"^(?P<title>.*?)\s?([\<\(]?(?P<part>\d{1})부[\>\)]?)?\s?(<(?P<subname1>.*)>)?\s?((?P<epnum>\d+)회)?\s?(<(?P<subname2>.*)>)?$"
 
     def get_svc_channels(self) -> List[dict]:
@@ -50,6 +49,7 @@ class DAUM(EPGProvider):
                 )
         return svc_channels
 
+    @no_endtime
     def get_programs(self) -> None:
         url = "https://search.daum.net/search?DA=B3T&w=tot&rtmaxcoll=B3T&q={}"
         for idx, _ch in enumerate(self.req_channels):

--- a/epg2xml/providers/kt.py
+++ b/epg2xml/providers/kt.py
@@ -68,7 +68,7 @@ class KT(EPGProvider):
                 )
         return svc_channels
 
-    def get_programs(self, lazy_write: bool = False) -> None:
+    def get_programs(self) -> None:
         url = "https://tv.kt.com/tv/channel/pSchedule.asp"
         params = {
             "ch_type": "1",  # 1: live 2: skylife 3: uhd live 4: uhd skylife
@@ -88,8 +88,6 @@ class KT(EPGProvider):
                     log.exception("프로그램 파싱 중 예외: %s, %s", _ch, day)
                 else:
                     _ch.programs.extend(_epgs)
-            if not lazy_write:
-                _ch.to_xml(self.cfg, no_endtime=self.no_endtime)
 
     def __epgs_of_day(self, channelid: str, data: str, day: datetime) -> List[EPGProgram]:
         _epgs = []

--- a/epg2xml/providers/kt.py
+++ b/epg2xml/providers/kt.py
@@ -6,7 +6,7 @@ from urllib.parse import unquote
 
 from bs4 import SoupStrainer
 
-from epg2xml.providers import EPGProgram, EPGProvider
+from epg2xml.providers import EPGProgram, EPGProvider, no_endtime
 from epg2xml.utils import ParserBeautifulSoup as BeautifulSoup
 
 log = logging.getLogger(__name__.rsplit(".", maxsplit=1)[-1].upper())
@@ -46,7 +46,6 @@ class KT(EPGProvider):
     """
 
     referer = "https://tv.kt.com/"
-    no_endtime = True
 
     def get_svc_channels(self) -> List[dict]:
         svc_channels = []
@@ -68,6 +67,7 @@ class KT(EPGProvider):
                 )
         return svc_channels
 
+    @no_endtime
     def get_programs(self) -> None:
         url = "https://tv.kt.com/tv/channel/pSchedule.asp"
         params = {

--- a/epg2xml/providers/lg.py
+++ b/epg2xml/providers/lg.py
@@ -58,7 +58,7 @@ class LG(EPGProvider):
             )
         return svc_channels
 
-    def get_programs(self, lazy_write: bool = False) -> None:
+    def get_programs(self) -> None:
         max_ndays = 5
         if int(self.cfg["FETCH_LIMIT"]) > max_ndays:
             log.warning(
@@ -91,8 +91,6 @@ class LG(EPGProvider):
                     log.exception("프로그램 파싱 중 예외: %s, %s", _ch, day)
                 else:
                     _ch.programs.extend(_epgs)
-            if not lazy_write:
-                _ch.to_xml(self.cfg, no_endtime=self.no_endtime)
 
     def __epgs_of_day(self, channelid: str, data: list) -> List[EPGProgram]:
         _epgs = []

--- a/epg2xml/providers/lg.py
+++ b/epg2xml/providers/lg.py
@@ -2,7 +2,7 @@ import logging
 from datetime import date, datetime, timedelta
 from typing import List
 
-from epg2xml.providers import EPGProgram, EPGProvider
+from epg2xml.providers import EPGProgram, EPGProvider, no_endtime
 
 log = logging.getLogger(__name__.rsplit(".", maxsplit=1)[-1].upper())
 
@@ -40,7 +40,6 @@ class LG(EPGProvider):
 
     referer = "https://www.lguplus.com/iptv/channel-guide"
     title_regex = r"\s?(?:\[.*?\])?(.*?)(?:\[(.*)\])?\s?(?:\(([\d,]+)회\))?\s?(<재>)?$"
-    no_endtime = True
 
     def get_svc_channels(self) -> List[dict]:
         svc_channels = []
@@ -58,6 +57,7 @@ class LG(EPGProvider):
             )
         return svc_channels
 
+    @no_endtime
     def get_programs(self) -> None:
         max_ndays = 5
         if int(self.cfg["FETCH_LIMIT"]) > max_ndays:

--- a/epg2xml/providers/naver.py
+++ b/epg2xml/providers/naver.py
@@ -3,7 +3,7 @@ from datetime import date, datetime, timedelta
 from typing import List
 from xml.sax.saxutils import unescape
 
-from epg2xml.providers import EPGProgram, EPGProvider
+from epg2xml.providers import EPGProgram, EPGProvider, no_endtime
 from epg2xml.utils import ParserBeautifulSoup as BeautifulSoup
 
 log = logging.getLogger(__name__.rsplit(".", maxsplit=1)[-1].upper())
@@ -29,7 +29,6 @@ class NAVER(EPGProvider):
     """
 
     referer = "https://m.search.naver.com/search.naver?where=m&query=%ED%8E%B8%EC%84%B1%ED%91%9C"
-    no_endtime = True
 
     def get_svc_channels(self) -> List[dict]:
         svc_channels = []
@@ -62,6 +61,7 @@ class NAVER(EPGProvider):
                     pass
         return svc_channels
 
+    @no_endtime
     def get_programs(self) -> None:
         url = "https://m.search.naver.com/p/csearch/content/nqapirender.nhn"
         params = {"key": "SingleChannelDailySchedule", "where": "m", "pkid": "66", "u1": "SVCID", "u2": "EPGDATE"}

--- a/epg2xml/providers/naver.py
+++ b/epg2xml/providers/naver.py
@@ -62,7 +62,7 @@ class NAVER(EPGProvider):
                     pass
         return svc_channels
 
-    def get_programs(self, lazy_write: bool = False) -> None:
+    def get_programs(self) -> None:
         url = "https://m.search.naver.com/p/csearch/content/nqapirender.nhn"
         params = {"key": "SingleChannelDailySchedule", "where": "m", "pkid": "66", "u1": "SVCID", "u2": "EPGDATE"}
 
@@ -81,8 +81,6 @@ class NAVER(EPGProvider):
                     log.exception("프로그램 파싱 중 예외: %s, %s", _ch, day)
                 else:
                     _ch.programs.extend(_epgs)
-            if not lazy_write:
-                _ch.to_xml(self.cfg, no_endtime=self.no_endtime)
 
     def __epgs_of_day(self, channelid: str, data: dict, day: datetime) -> List[EPGProgram]:
         _epgs = []

--- a/epg2xml/providers/sk.py
+++ b/epg2xml/providers/sk.py
@@ -55,7 +55,7 @@ class SK(EPGProvider):
                 )
         return svc_channels
 
-    def get_programs(self, lazy_write: bool = False) -> None:
+    def get_programs(self) -> None:
         max_ndays = 3
         if int(self.cfg["FETCH_LIMIT"]) > max_ndays:
             log.warning(
@@ -90,8 +90,6 @@ class SK(EPGProvider):
                     log.exception("프로그램 파싱 중 예외: %s, %s", _ch, day)
                 else:
                     _ch.programs.extend(_epgs)
-            if not lazy_write:
-                _ch.to_xml(self.cfg, no_endtime=self.no_endtime)
 
     def __epgs_of_day(self, channelid: str, data: list, day: datetime) -> List[EPGProgram]:
         _epgs = []

--- a/epg2xml/providers/sk.py
+++ b/epg2xml/providers/sk.py
@@ -34,7 +34,6 @@ class SK(EPGProvider):
 
     referer = "https://cyber.skbroadband.com/"
     title_regex = r"^(.*?)(\(([\d,]+)회\))?(<(.*)>)?(\((재)\))?$"
-    no_endtime = False
 
     def get_svc_channels(self) -> List[dict]:
         svc_channels = []

--- a/epg2xml/providers/spotv.py
+++ b/epg2xml/providers/spotv.py
@@ -18,7 +18,6 @@ class SPOTV(EPGProvider):
 
     referer = "https://www.spotvnow.co.kr/channel"
     title_regex = r"\s?(?:\[(.*?)\])?\s?(.*?)\s?(?:\((.*)\))?\s?(?:<([\d,]+)회>)?\s?$"
-    no_endtime = False
 
     def get_svc_channels(self) -> List[dict]:
         url = "https://www.spotvnow.co.kr/api/v3/channel"

--- a/epg2xml/providers/spotv.py
+++ b/epg2xml/providers/spotv.py
@@ -38,7 +38,7 @@ class SPOTV(EPGProvider):
             return datetime.strptime(dt.replace("24:00", "00:00"), "%Y-%m-%d %H:%M") + timedelta(days=1)
         return datetime.strptime(dt, "%Y-%m-%d %H:%M")
 
-    def get_programs(self, lazy_write: bool = False) -> None:
+    def get_programs(self) -> None:
         max_ndays = 5
         if int(self.cfg["FETCH_LIMIT"]) > max_ndays:
             log.warning(
@@ -73,8 +73,6 @@ class SPOTV(EPGProvider):
                 log.exception("프로그램 파싱 중 예외: %s", _ch)
             else:
                 _ch.programs.extend(_epgs)
-            if not lazy_write:
-                _ch.to_xml(self.cfg, no_endtime=self.no_endtime)
 
     def __epgs_of_channel(self, channelid: str, data: dict, svcid: str) -> List[EPGProgram]:
         programs = [x for x in data if x["channelId"] == svcid]

--- a/epg2xml/providers/tving.py
+++ b/epg2xml/providers/tving.py
@@ -34,7 +34,6 @@ class TVING(EPGProvider):
     """
 
     referer = "https://www.tving.com/schedule/main.do"
-    no_endtime = False
 
     url = "https://api.tving.com/v2/media/schedules"
     params = {

--- a/epg2xml/providers/tving.py
+++ b/epg2xml/providers/tving.py
@@ -104,7 +104,7 @@ class TVING(EPGProvider):
             if x["schedules"] is not None
         ]
 
-    def get_programs(self, lazy_write: bool = False) -> None:
+    def get_programs(self) -> None:
         def grouper(iterable, n):
             it = iter(iterable)
             group = tuple(islice(it, n))
@@ -135,8 +135,6 @@ class TVING(EPGProvider):
                     log.exception("프로그램 파싱 중 예외: %s", _ch)
                 else:
                     _ch.programs.extend(_epgs)
-                if not lazy_write:
-                    _ch.to_xml(self.cfg, no_endtime=self.no_endtime)
 
     def __epgs_of_channel(self, channelid: str, data: dict) -> List[EPGProgram]:
         _epgs = []

--- a/epg2xml/providers/wavve.py
+++ b/epg2xml/providers/wavve.py
@@ -121,7 +121,7 @@ class WAVVE(EPGProvider):
         _epg.crew += [{"name": x["text"], "title": "writer"} for x in writers["list"]]
         return _epg
 
-    def get_programs(self, lazy_write: bool = False) -> None:
+    def get_programs(self) -> None:
         # parameters for requests
         params = {
             "enddatetime": (today + timedelta(days=int(self.cfg["FETCH_LIMIT"]) - 1)).strftime("%Y-%m-%d 24:00"),
@@ -141,8 +141,6 @@ class WAVVE(EPGProvider):
                     log.exception("프로그램 파싱 중 예외: %s", _ch)
                 else:
                     _ch.programs.append(_epg)
-            if not lazy_write:
-                _ch.to_xml(self.cfg, no_endtime=self.no_endtime)
 
     @lru_cache
     def get_program_details(self, programid: str) -> dict:

--- a/epg2xml/providers/wavve.py
+++ b/epg2xml/providers/wavve.py
@@ -21,7 +21,6 @@ class WAVVE(EPGProvider):
 
     referer = "https://www.wavve.com/"
     title_regex = r"^(.*?)(?:\s*[\(<]?([\d]+)회[\)>]?)?(?:\([월화수목금토일]?\))?(\([선별전주\(\)재방]*?재[\d방]?\))?\s*(?:\[(.+)\])?$"
-    no_endtime = False
 
     base_url = "https://apis.wavve.com"
     base_params = {

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -68,7 +68,7 @@ if len(sys.argv) > 2:
     provider.req_channels = rch
 
 stime = timer()
-provider.get_programs(lazy_write=True)
+provider.get_programs()
 etime_prog = timer() - stime
 num_rch = len(provider.req_channels)
 


### PR DESCRIPTION
## 언제나 lazy_write=True

본 커밋으로 더 이상 get_programs()에서  채널 단위로 완료 후 flush하여 쓰지 않는다. 즉 lazy_write 옵션이 언제나 True로 동작하며 XML로 쓰기는 별도의 메서드에서 실행된다. 대신 메모리 사용량이 다소 올라갈 것으로 예상

이는 로직의 일관성, 모듈 분리를 가능하게 하기 위함