### PR TITLE
테스트 방법 개선

### DIFF
--- a/.github/workflows/stats.yml
+++ b/.github/workflows/stats.yml
@@ -1,4 +1,4 @@
-name: providers
+name: stats
 
 on:
   workflow_dispatch:

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -1,23 +1,30 @@
-name: test providers all
+name: providers
 
 on:
   workflow_dispatch:
+    inputs:
+      numChannels:
+        description: 'Number of test channels'
+        required: true
+        default: '0'
+      shuffle:
+        description: 'Shuffle test channels'
+        required: true
+        default: 'false'
 
 jobs:
-  test:
+  stats:
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
-        provider: [kt, lg, sk, daum, naver, tving, spotv]
+        provider: [kt, lg, sk, daum, naver, tving, wavve, spotv]
         python-version: ['3.8', '3.12']
     steps:
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Display Python version
-      run: python -c "import sys; print(sys.version)"
     - name: Checkout
       uses: actions/checkout@v4
     - name: Install dependencies
@@ -27,7 +34,13 @@ jobs:
         sudo apt-get install -y xmltv-util
     - name: Test ${{ matrix.provider }}
       run: |
-        python -m tests.test_provider ${{ matrix.provider }}
+        if [ "${{ matrix.provider }}" = "wavve" ]; then
+          export HTTP_PROXY="${{ secrets.HTTP_PROXY }}"
+        fi
+        python -m tests.test_provider \
+          ${{ matrix.provider }} \
+          ${{ github.event.inputs.numChannels }} \
+          ${{ github.event.inputs.shuffle }}
     - name: Upload Artifact
       uses: actions/upload-artifact@v4
       if: always()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
       run: |
         rm -f epg2xml.json && epg2xml run
         jq --arg U "${{ secrets.HTTP_PROXY }}" \
-          '.WAVVE = {"HTTP_PROXY": $U}' epg2xml.json | sponge epg2xml.json
+          '.WAVVE += {"HTTP_PROXY": $U}' epg2xml.json | sponge epg2xml.json
         epg2xml update_channels
         for p in KT LG SK DAUM NAVER TVING WAVVE SPOTV; do
           jq -c '.'$p'.CHANNELS[]' Channel.json | shuf -n10 | jq --slurpfile n /dev/stdin \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,8 +22,9 @@ jobs:
       uses: actions/checkout@v4
     - name: Install dependencies
       run: |
+        python -m pip install --upgrade pip
         pip install .[lxml]
-        sudo apt-get install -y --no-install-recommends \
+        sudo apt-get install -yqq --no-install-recommends \
           xmltv-util \
           moreutils
     - name: Set up epg2xml.json
@@ -62,6 +63,7 @@ jobs:
           exit 0
         fi
         tv_validate_file xmltv-main.xml
+        exit 1
     - name: Upload Artifact
       uses: actions/upload-artifact@v4
       if: always()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: test providers
+name: test
 
 on:
   push:
@@ -7,34 +7,53 @@ on:
   pull_request:
   workflow_dispatch:
 
+env:
+  PY_VER: 3.10
+
 jobs:
   test:
     runs-on: ubuntu-22.04
-    strategy:
-      fail-fast: false
-      matrix:
-        provider: [kt, lg, sk, daum, naver, tving, spotv]
-        python-version: ['3.8', '3.12']
     steps:
-    - name: Set up Python ${{ matrix.python-version }}
+    - name: Set up Python ${{ env.PY_VER }}
       uses: actions/setup-python@v5
       with:
-        python-version: ${{ matrix.python-version }}
-    - name: Display Python version
-      run: python -c "import sys; print(sys.version)"
+        python-version: ${{ env.PY_VER }}
     - name: Checkout
       uses: actions/checkout@v4
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install .[lxml]
-        sudo apt-get install -y xmltv-util
-    - name: Test ${{ matrix.provider }}
+        sudo apt-get install -y xmltv-util moreutils
+    - name: Set up epg2xml.json
       run: |
-        python -m tests.test_provider ${{ matrix.provider }} 0.1 --shuffle
+        rm -f epg2xml.json && epg2xml run
+        jq --arg U "${{ secrets.HTTP_PROXY }}" \
+          '.WAVVE = {"HTTP_PROXY": $U}' epg2xml.json | sponge epg2xml.json
+        epg2xml update_channels
+        for p in KT LG SK DAUM NAVER TVING WAVVE SPOTV; do
+          jq -c '.'$p'.CHANNELS[]' Channel.json | shuf -n10 | jq --slurpfile n /dev/stdin \
+            '.'$p'.MY_CHANNELS = $n' epg2xml.json | sponge epg2xml.json
+        done
+    - name: Test
+      run: |
+        epg2xml run \
+          --xmlfile=xmltv.xml \
+          --loglevel=DEBUG
+    - name: Diff
+      if: github.ref == 'refs/heads/main' && github.event_name == 'pull_request'
+      run: |
+        pip install --upgrade "epg2xml[lxml] @ git+https://github.com/epg2xml/epg2xml.git@main"
+        epg2xml run \
+          --xmlfile=xmltv-main.xml \
+          --loglevel=DEBUG \
+          --parallel
+        if diff -I '^<tv generator-info-name*' xmltv.xml xmltv-main.xml; then
+          rm xmltv-main.xml
+        fi
     - name: Upload Artifact
       uses: actions/upload-artifact@v4
       if: always()
       with:
-        name: xmltv-${{ matrix.provider }}-py${{ matrix.python-version }}
-        path: xmltv_${{ matrix.provider }}.xml
+        name: xmltv
+        path: xmltv*.xml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,9 +22,10 @@ jobs:
       uses: actions/checkout@v4
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install .[lxml]
-        sudo apt-get install -y xmltv-util moreutils
+        sudo apt-get install -y --no-install-recommends \
+          xmltv-util \
+          moreutils
     - name: Set up epg2xml.json
       run: |
         rm -f epg2xml.json && epg2xml run
@@ -43,7 +44,7 @@ jobs:
         sed -i 's@</tv>@@g' xmltv.xml
         tv_validate_file xmltv.xml
     - name: Diff
-      if: github.ref == 'refs/heads/main' && github.event_name == 'pull_request'
+      if: github.event.pull_request.base.ref == 'main'
       run: |
         pip install --upgrade "epg2xml[lxml] @ git+https://github.com/epg2xml/epg2xml.git@main"
         epg2xml run \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,10 +8,10 @@ on:
   workflow_dispatch:
 
 env:
-  PY_VER: 3.10
+  PY_VER: '3.10'
 
 jobs:
-  test:
+  base:
     runs-on: ubuntu-22.04
     steps:
     - name: Set up Python ${{ env.PY_VER }}
@@ -35,7 +35,7 @@ jobs:
           jq -c '.'$p'.CHANNELS[]' Channel.json | shuf -n10 | jq --slurpfile n /dev/stdin \
             '.'$p'.MY_CHANNELS = $n' epg2xml.json | sponge epg2xml.json
         done
-    - name: Test
+    - name: Run
       run: |
         epg2xml run \
           --xmlfile=xmltv.xml \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,10 +28,17 @@ jobs:
           moreutils
     - name: Set up epg2xml.json
       run: |
+        # 기본 설정파일 생성
         rm -f epg2xml.json && epg2xml run
+        # 예외 적용 - WAVVE HTTP_PROXY
         jq --arg U "${{ secrets.HTTP_PROXY }}" \
           '.WAVVE += {"HTTP_PROXY": $U}' epg2xml.json | sponge epg2xml.json
+        # 예외 적용 - DAUM ID_FORMAT
+        jq --arg ID "{No}.{Source.lower()}" \
+          '.DAUM += {"ID_FORMAT": $ID}' epg2xml.json | sponge epg2xml.json
+        # 채널 업데이트
         epg2xml update_channels
+        # 최대 10개의 채널을 무작위 추출
         for p in KT LG SK DAUM NAVER TVING WAVVE SPOTV; do
           jq -c '.'$p'.CHANNELS[]' Channel.json | shuf -n10 | jq --slurpfile n /dev/stdin \
             '.'$p'.MY_CHANNELS = $n' epg2xml.json | sponge epg2xml.json

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,6 @@ jobs:
         epg2xml run \
           --xmlfile=xmltv.xml \
           --loglevel=DEBUG
-        sed -i 's@</tv>@@g' xmltv.xml
         tv_validate_file xmltv.xml
     - name: Diff
       if: github.event.pull_request.base.ref == 'main'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,12 +58,10 @@ jobs:
           --xmlfile=xmltv-main.xml \
           --loglevel=DEBUG \
           --parallel
-        if diff xmltv.xml xmltv-main.xml; then
-          rm xmltv-main.xml
-          exit 0
+        if ! diff -I '^<tv generator-info-name*' xmltv.xml xmltv-main.xml; then
+          tv_validate_file xmltv-main.xml
+          exit 1
         fi
-        tv_validate_file xmltv-main.xml
-        exit 1
     - name: Upload Artifact
       uses: actions/upload-artifact@v4
       if: always()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,7 @@ on:
 
 env:
   PY_VER: '3.10'
+  EPG2XML_LOGLEVEL: DEBUG
 
 jobs:
   base:
@@ -46,9 +47,7 @@ jobs:
         done
     - name: Run
       run: |
-        epg2xml run \
-          --xmlfile=xmltv.xml \
-          --loglevel=DEBUG
+        epg2xml run --xmlfile=xmltv.xml
         tv_validate_file xmltv.xml
     - name: Diff
       if: github.event.pull_request.base.ref == 'main'
@@ -56,7 +55,6 @@ jobs:
         pip install --upgrade "epg2xml[lxml] @ git+https://github.com/epg2xml/epg2xml.git@main"
         epg2xml run \
           --xmlfile=xmltv-main.xml \
-          --loglevel=DEBUG \
           --parallel
         if ! diff -I '^<tv generator-info-name*' xmltv.xml xmltv-main.xml; then
           tv_validate_file xmltv-main.xml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,9 +57,11 @@ jobs:
           --xmlfile=xmltv-main.xml \
           --loglevel=DEBUG \
           --parallel
-        if diff -I '^<tv generator-info-name*' xmltv.xml xmltv-main.xml; then
+        if diff xmltv.xml xmltv-main.xml; then
           rm xmltv-main.xml
+          exit 0
         fi
+        tv_validate_file xmltv-main.xml
     - name: Upload Artifact
       uses: actions/upload-artifact@v4
       if: always()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,6 +40,8 @@ jobs:
         epg2xml run \
           --xmlfile=xmltv.xml \
           --loglevel=DEBUG
+        sed -i 's@</tv>@@g' xmltv.xml
+        tv_validate_file xmltv.xml
     - name: Diff
       if: github.ref == 'refs/heads/main' && github.event_name == 'pull_request'
       run: |

--- a/epg2xml/providers/__init__.py
+++ b/epg2xml/providers/__init__.py
@@ -337,7 +337,8 @@ class EPGProvider:
 
     def write_channels(self) -> None:
         for ch in self.req_channels:
-            ch.to_xml()
+            if ch.programs:
+                ch.to_xml()
 
     def get_programs(self) -> None:
         raise NotImplementedError("method 'get_programs' must be implemented")

--- a/epg2xml/providers/__init__.py
+++ b/epg2xml/providers/__init__.py
@@ -337,8 +337,10 @@ class EPGProvider:
 
     def write_channels(self) -> None:
         for ch in self.req_channels:
-            if ch.programs:
-                ch.to_xml()
+            if not ch.programs:
+                log.warning("Skip writing as no program entries found for '%s'", ch.id)
+                continue
+            ch.to_xml()
 
     def get_programs(self) -> None:
         raise NotImplementedError("method 'get_programs' must be implemented")


### PR DESCRIPTION
### 기존의 테스트는 stats로 전환

* 파이썬 버전 호환성 및 제공자 별로 matrix를 구성해 매 commit / PR 마다 동작하던 workflow는 stats로 전환
* 릴리즈나 필요에 따라 비정기적으로 실행

### 새로운 테스트

* 파이썬 버전 3.10
* 채널 수는 제공자별로 무작위로 최대 10개
* 차단으로 테스트 불가했던 일부 제공자도 외부 프록시를 이용해 테스트 가능하도록
* PR의 경우 main 브랜치의 결과(xmlfile)와 비교 단계 추가 (이 때 parallel 옵션으로 테스트)
* 설정 파일을 고정해 전 제공자를 하나의 런타임에 테스트
* 실제 콘솔에서 실행하는 것과 유사하게 시나리오 구성
