### PR TITLE
fix KBS channel list regex

### DIFF
--- a/epg2xml/providers/kbs.py
+++ b/epg2xml/providers/kbs.py
@@ -19,7 +19,7 @@ class KBS(EPGProvider):
     max_batch_channels = 5  # 20까지 가능하지만 과도한 요청을 방지하기 위해...
 
     PTN_CHANNEL_LIST = re.compile(
-        r"var\s+channelList\s*=\s*JSON\.parse\('(?P<data>.*?)'\);",
+        r"window\.adminChannelList\s*=\s*JSON\.parse\('(?P<data>.*?)'\)",
         flags=re.DOTALL,
     )
 


### PR DESCRIPTION
This changes the KBS channel list parser to match the new `window.adminChannelList` payload shape.

What changed:
- Updated only the KBS channel list regex to match the new window.adminChannelList assignment.

Why:
- The previous pattern only matched the old channelList form, so service channels could not be loaded after the upstream markup change.

Validation:
- python -m py_compile epg2xml/providers/kbs.py